### PR TITLE
dockerをローカルで動かす際に必要なファイルを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.13.4-alpine
+
+RUN apk add --update --no-cache ca-certificates git
+
+WORKDIR /src/
+
+ENTRYPOINT ["sh","scripts/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.6"
+services:
+  app:
+    build: .
+    image: bookmark_tarou
+    volumes:
+      - .:/src
+    links:
+      - db
+    ports:
+      - "8000:8000"
+    environment:
+      PORT: 8000
+      DATABASE_DSN: root@(db:3306)/bookmark_tarou
+      DATABASE_DSN_TEST: root@(db:3306)/bookmark_tarou_test
+    tty: true
+    stdin_open: true
+  db:
+    image: mysql:8.0
+    volumes:
+      - ./db/docker:/docker-entrypoint-initdb.d
+      - .:/app
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,0 +1,2 @@
+go mod download
+ls


### PR DESCRIPTION
## 背景

- こんごDBにデータをもりもり追加すると思うので、今のうちにDockerでDBと連携したい
- アプリケーションもビルドしたいのでついでにこちらのDockerfileの枠組みだけ作っておく

## 作業

https://github.com/AnaTofuZ/BookmarkTarou/commit/461974f35fc08e30fe6799c8a3b8c2c0cf54b6bd
のみ

## 内容
- アプリケーションを担当するdockerfileと、mysqlをdocker-composeで連携させた。
- アプリケーションのビルド時に必要なentrypoint.sh(キャッシュ対策)も追加した